### PR TITLE
Web Components Support

### DIFF
--- a/src/vue-tel-input.vue
+++ b/src/vue-tel-input.vue
@@ -502,7 +502,7 @@ export default {
         // Define Handler and cache it on the element
         var bubble = binding.modifiers.bubble;
         var handler = function (e) {
-          if (bubble || (!el.contains(e.target) && el !== e.target)) {
+          if (bubble || (!el.contains(e.path[0]) && el !== e.path[0])) {
             binding.value(e)
           }
         };


### PR DESCRIPTION
The 'click-outside' Vue directive is not working when using it inside a web component.

In order to mantain the web components encapsulation principle, when the ‘click’ event is triggered from an element that is inside of the “#shadow-root”, the browser retargets the event to the host element of the shadow dom.

![image](https://user-images.githubusercontent.com/10757341/59162660-0ced2700-8af5-11e9-856f-1add61c0c2ba.png)

For example, clicking the element `<p data-v-9b69508e=""> I'm a web component</p>,` the `e.target` code returns `<my-web-component>` as clicked element:

![image](https://user-images.githubusercontent.com/10757341/59162675-7836f900-8af5-11e9-9382-6367317c2884.png)

So the problem is the `e.target` code that is retargeted to the host element. 

To solve this, we can use instead the `e.path[0]` code to get the clicked element to add support to use it inside web components.


