### PR TITLE
Add open and close event emits

### DIFF
--- a/src/vue-tel-input.vue
+++ b/src/vue-tel-input.vue
@@ -346,6 +346,14 @@ export default {
     value() {
       this.phone = this.value;
     },
+    open(isDropdownOpened) {
+      // Emit open and close events
+      if (isDropdownOpened) {
+        this.$emit('open');
+      } else {
+        this.$emit('close');
+      }
+    }
   },
   methods: {
     initializeCountry() {


### PR DESCRIPTION
### Overview
This Pull request includes `open` and `close` event emits, in order to inform the parent component when the the dropdown is opened.

### Details
Added a watcher for the `open` state, in order to emit open or close event, when `open` changes to `true` or `false` accordingly.