### PR TITLE
[ADD] id as a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Read more on `vue-form-generator`'s [instruction page](https://icebob.gitbooks.i
   | `maxLen` | `Number` | `25` | Native input 'maxlength' attribute |
   | `wrapperClasses` | `String | Array | Object` | `''` | Custom classes for the wrapper |
   | `inputClasses` | `String | Array | Object` | `''` | Custom classes for the `input` |
+  | `inputId` | `String` | `''` | Custom 'id' for the `input` |
   | `dropdownOptions` | `Object` | `{ disabledDialCode: false, tabindex: 0 }` | Options for dropdown, supporting `disabledDialCode` and `tabindex`| 
   | `inputOptions` | `Object` | `{ showDialCode: false, tabindex: 0 }` | Options for input, supporting `showDialCode` (always show dial code in the input) and `tabindex`|
   | `validCharactersOnly` | `Boolean` | `false` | Only allow valid characters in a phone number (will also verify in `mounted`, so phone number with invalid characters will be shown as an empty string) |

--- a/src/vue-tel-input.vue
+++ b/src/vue-tel-input.vue
@@ -39,6 +39,7 @@
       :autocomplete="autocomplete"
       :name="name"
       :class="inputClasses"
+      :id="inputId"
       :maxlength="maxLen"
       @blur="onBlur"
       @input="onInput"
@@ -217,6 +218,10 @@ export default {
     },
     inputClasses: {
       type: [String, Array, Object],
+      default: '',
+    },
+    inputId: {
+      type: 'String',
       default: '',
     },
     dropdownOptions: {


### PR DESCRIPTION
According to this [issue](https://github.com/EducationLink/vue-tel-input/issues/90) the `id` attribute should be mandatory for every input element