### PR TITLE
created the 'сustom-validate' prop to validate with regex

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
       <div style="width: 500px; margin: 20px auto;">
         <vue-tel-input
           :preferred-countries="['us', 'gb', 'ua']"
-          :valid-characters-only="true"
+          :custom-validate="/^[0-9]*$/"
           @input="onInput"/>
       </div>
       <div

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -219,6 +219,10 @@ export default {
       type: Boolean,
       default: () => getDefault('validCharactersOnly'),
     },
+    customValidate: {
+      type: [Boolean, RegExp],
+      default: () => getDefault('customValidate'),
+    },
     dynamicPlaceholder: {
       type: Boolean,
       default: () => getDefault('dynamicPlaceholder'),
@@ -319,7 +323,9 @@ export default {
       }
     },
     phone(newValue, oldValue) {
-      if (this.validCharactersOnly && !this.testCharacters()) {
+      const isValidCharactersOnly = this.validCharactersOnly && !this.testCharacters();
+      const isCustomValidate = this.customValidate && !this.testCustomValidate();
+      if (isValidCharactersOnly || isCustomValidate) {
         this.$nextTick(() => { this.phone = oldValue; });
       } else if (newValue) {
         if (newValue[0] === '+') {
@@ -466,8 +472,14 @@ export default {
       const re = /^[()\-+0-9\s]*$/;
       return re.test(this.phone);
     },
+    testCustomValidate() {
+      return this.customValidate instanceof RegExp ? this.customValidate.test(this.phone) : false;
+    },
     onInput(e) {
       if (this.validCharactersOnly && !this.testCharacters()) {
+        return;
+      }
+      if (this.customValidate && !this.testCustomValidate()) {
         return;
       }
       this.$refs.input.setCustomValidity(this.phoneObject.valid ? '' : this.invalidMsg);

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,7 @@ export const defaultOptions = {
   inputOptions: {},
   maxLen: 25,
   validCharactersOnly: false,
+  customValidate: false,
   dynamicPlaceholder: false,
 };
 


### PR DESCRIPTION
Has been added new attribute `custom-validate` which takes the value as a regular expression. 
For example. Limit to entering the numbers only.

`<vue-tel-input :custom-validate="/^[0-9]*$/" />`

It helps to solve the issue https://github.com/EducationLink/vue-tel-input/issues/27