### PR TITLE
Added defaultCountryByDialCode prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Read more on `vue-form-generator`'s [instruction page](https://icebob.gitbooks.i
   | `autocomplete` | `String` | `'on'` | Native input 'autocomplete' attribute |
   | `autofocus` | `Boolean` | `false` | Native input 'autofocus' attribute |
   | `defaultCountry` | `String` | `''` | Default country, will override the country fetched from IP address of user |
+  | `defaultCountryByDialCode` | `String` | `''` | Default country by dial code, will override the country fetched from IP address of user |
   | `disabled` | `Boolean` | `false` | Disable input field |
   | `disabledFetchingCountry` | `Boolean` | `false` | Disable fetching current country based on IP address of user |
   | `dropdownOptions` | `Object` | `{ disabledDialCode: false, tabindex: 0 }` | Options for dropdown, supporting `disabledDialCode` and `tabindex`| 

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -156,6 +156,12 @@ export default {
       type: String,
       default: () => getDefault('defaultCountry'),
     },
+    defaultCountryByDialCode: {
+      // Default country by dial code, ie: '44'
+      // Will override the current country of user
+      type: String,
+      default: () => getDefault('defaultCountryByDialCode'),
+    },
     enabledCountryCode: {
       type: Boolean,
       default: () => getDefault('enabledCountryCode'),
@@ -394,6 +400,13 @@ export default {
             resolve();
             return;
           }
+        } else if (this.defaultCountryByDialCode) {
+          const defaultCountry = this.findCountryByDialCode(this.defaultCountryByDialCode);
+          if (defaultCountry) {
+            this.choose(defaultCountry);
+            resolve();
+            return;
+          }
         }
         const fallbackCountry = this.findCountry(this.preferredCountries[0])
           || this.filteredCountries[0];
@@ -434,6 +447,9 @@ export default {
     },
     findCountry(iso = '') {
       return this.allCountries.find(country => country.iso2 === iso.toUpperCase());
+    },
+    findCountryByDialCode(dialCode = '') {
+      return this.allCountries.find(country => country.dialCode === dialCode);
     },
     getItemClass(index, iso2) {
       const highlighted = this.selectedIndex === index;

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,7 @@ export const defaultOptions = {
   required: false,
   allCountries,
   defaultCountry: '',
+  defaultCountryByDialCode: '',
   enabledCountryCode: false,
   enabledFlags: true,
   preferredCountries: [],


### PR DESCRIPTION
Have added `defaultCountryByDialCode` prop, very similar to `defaultCountry` but uses `dialCode`
 instead of `iso2` for country map.
`<vue-tel-input defaultCountryByDialCode="44" />`