### PR TITLE
fix: use significant instead of national

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -457,9 +457,9 @@ export default {
       if (this.phone
         && this.phone[0] === '+'
         && this.activeCountry.iso2
-        && this.phoneObject.number.national) {
+        && this.phoneObject.number.significant) {
         // Attach the current phone number with the newly selected country
-        this.phone = PhoneNumber(this.phoneObject.number.national, this.activeCountry.iso2)
+        this.phone = PhoneNumber(this.phoneObject.number.significant, this.activeCountry.iso2)
           .getNumber('international');
       } else if (this.inputOptions && this.inputOptions.showDialCode && parsedCountry) {
         // Reset phone if the showDialCode is set


### PR DESCRIPTION
**What's the problem this PR addresses?**

When switching between some countries, a valid number with a prefix gets a zero prepended to it causing the number to become invalid. In my case switching from Norway to Sweden and back to Norway causes a valid number to become invalid

**How did you fix it?**

Switch to use the significant part of the number, instead of national