### PR TITLE
fix #179: pressing Enter in country selector does not re-validate phone number

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -521,7 +521,7 @@ export default {
       } else if (e.keyCode === 13) {
         // enter key
         if (this.selectedIndex !== null) {
-          this.choose(this.sortedCountries[this.selectedIndex]);
+          this.choose(this.sortedCountries[this.selectedIndex], true);
         }
         this.open = !this.open;
       } else {


### PR DESCRIPTION
`this.choose` upon `e.keyCode === 13` was missing `true` option.