### PR TITLE
fix: change country flag on click, even if international mode is NOT used

### DIFF
--- a/docs/documentation/installation.md
+++ b/docs/documentation/installation.md
@@ -30,6 +30,8 @@ export default {
   },
 };
 </script>
+
+<style src="vue-tel-input/dist/vue-tel-input.css"></style>
 ```
 
 ## Browser

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "vue-cli-service build --target lib src/index.js",
     "docs:build": "vuepress build docs",
     "test:unit": "vue-cli-service test:unit",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "dist/"

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -433,7 +433,12 @@ export default {
       if (this.inputOptions?.showDialCode && parsedCountry) {
         // Reset phone if the showDialCode is set
         this.phone = `+${parsedCountry.dialCode}`;
+        return;
       }
+
+      // update value, even if international mode is NOT used
+      this.activeCountryCode = parsedCountry.iso2;
+      this.$emit('input', this.phone, this.phoneObject);
     },
     testCharacters() {
       if (this.validCharactersOnly) {

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -36,7 +36,7 @@
     <input
       v-model="phone"
       ref="input"
-      type="tel"
+      :type="type"
       :autocomplete="autocomplete"
       :autofocus="autofocus"
       :class="['vti__input', inputClasses]"
@@ -181,6 +181,10 @@ export default {
     required: {
       type: Boolean,
       default: () => getDefault('required'),
+    },
+    type: {
+      type: String,
+      default: () => getDefault('tel'),
     },
     validCharactersOnly: {
       type: Boolean,

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -184,7 +184,7 @@ export default {
     },
     type: {
       type: String,
-      default: () => getDefault('tel'),
+      default: () => getDefault('type'),
     },
     validCharactersOnly: {
       type: Boolean,

--- a/src/utils.js
+++ b/src/utils.js
@@ -128,6 +128,9 @@ export const allProps = [
     name: 'required', default: false, type: Boolean, description: '', inDemo: false,
   },
   {
+    name: 'type', default: 'tel', type: String, description: '', inDemo: false,
+  },
+  {
     name: 'validCharactersOnly', default: false, type: Boolean, description: '', inDemo: true,
   },
   {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,3 @@
 module.exports = {
   lintOnSave: true,
-  css: {
-    extract: true
-  }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   lintOnSave: true,
+  css: {
+    extract: true
+  }
 }


### PR DESCRIPTION
This PR also extracts the css so you can import it, if you are using the component directly (and not as a plugin).
Also we added the ability to change the input property "type" via a property, if needed.