### PR TITLE
Add aria-label for the country code dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-tel-input",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "International Telephone Input with Vue",
   "author": "Steven Dao <iamstevendao@gmail.com>",
   "license": "MIT",

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -2,7 +2,7 @@
   <div ref="refRoot"
        :class="['vue-tel-input', styleClasses, { disabled }]">
     <div v-click-outside="clickedOutside"
-         aria-label="Country Code Selector"
+         :aria-label="dropdownOptions.ariaLabel"
          aria-haspopup="listbox"
          :aria-expanded="data.open"
          role="button"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,7 @@ export type PhoneMeta = {
 };
 
 export interface DropdownOptions {
+  ariaLabel?: string
   disabled?: boolean
   showDialCodeInList?: boolean
   showDialCodeInSelection?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,6 +81,13 @@ export const allProps = [
     inDemo: false,
   },
   {
+    name: 'dropdownOptions.ariaLabel',
+    default: 'Country Code Selector',
+    type: String,
+    description: 'Aria label for the country code selector dropdown',
+    inDemo: false,
+  },
+  {
     name: 'dropdownOptions.disabled',
     default: false,
     type: Boolean,


### PR DESCRIPTION
Add an option to set the aria-label of the dropdown so the component is accessible.