### PR TITLE
Fix keyboard navigation

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -592,7 +592,7 @@
   function clickedOutside() {
     data.open = false;
   }
-  function keyboardNav(e: KeyboardEvent) {
+  async function keyboardNav(e: KeyboardEvent) {
     if (e.keyCode === 40) {
       // down arrow
       e.preventDefault();
@@ -602,6 +602,7 @@
       } else {
         data.selectedIndex = Math.min(sortedCountries.value.length - 1, data.selectedIndex + 1);
       }
+      if (!refList.value) await nextTick()
       const selEle = refList.value.children[data.selectedIndex] as HTMLLIElement;
       selEle.focus();
       if (selEle.offsetTop + selEle.clientHeight
@@ -619,6 +620,7 @@
       } else {
         data.selectedIndex = Math.max(0, data.selectedIndex - 1);
       }
+      if (!refList.value) await nextTick()
       const selEle = refList.value.children[data.selectedIndex] as HTMLLIElement;
       selEle.focus();
       if (selEle.offsetTop < refList.value.scrollTop) {


### PR DESCRIPTION
When you place the keyboard cursor on the flags and press the up or down arrow, the following error appears: `Uncaught TypeError: can't access property ‘children’, refList.value is null.` 
This is because there is a v-if on the referenced element, which means that it has not yet been created when you try to access its children. 

My solution is to wait for the DOM to refresh. 