### PR TITLE
fix: correct TypeScript exports

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,4 @@
-import { DefineComponent } from "vue";
+import { App, DefineComponent } from "vue";
 import type { CountryCode, PhoneNumber } from "libphonenumber-js";
 
 export interface DropdownOptions {
@@ -277,11 +277,18 @@ export interface VueTelInputEmits {
     [key: string]: (...args: any[]) => void;
 }
 
-declare const VueTelInput: DefineComponent<VueTelInputProps, {}, {}, {}, {}, {}, {}, VueTelInputEmits> & {
-    install: (app: any, options?: any) => void;
-};
+declare const VueTelInput: DefineComponent<VueTelInputProps, {}, {}, {}, {}, {}, {}, VueTelInputEmits>;
 
-export default VueTelInput;
+export type VueTelInputPluginOptions = Omit<VueTelInputProps, "modelValue">;
+
+export interface VueTelInputPlugin {
+    install: (app: App, options?: VueTelInputPluginOptions) => void;
+}
+
+declare const plugin: VueTelInputPlugin;
+
+export { VueTelInput };
+export default plugin;
 
 declare module "@vue/runtime-core" {
     interface GlobalComponents {


### PR DESCRIPTION
The declaration file was marking VueTelInput as the default export, but the runtime module exposes it as a named export and keeps the plugin as the default export.

This updates the types to match the real module shape so both of these usages are typed correctly:
- import { VueTelInput } from 'vue-tel-input'
- import VueTelInputPlugin from 'vue-tel-input'

This fixes the issue reported in #524 and avoids confusing TypeScript errors for consumers.

Fixed and check against a repository running vue-tel-input in version 9.7.1

Closes #524 