### PR TITLE
feat: add inputmode support

### DIFF
--- a/src/components/vue-tel-input.test.ts
+++ b/src/components/vue-tel-input.test.ts
@@ -271,6 +271,17 @@ describe('Props', () => {
         expect(wrapper.find('.vti__input').attributes('maxlength')).toBe('20');
       })
     });
+    it('.inputmode sets `inputmode` native attribute of input', () => {
+      const wrapper = shallowMount(VueTelInput, {
+        props: {
+          inputOptions: { inputmode: 'tel' },
+        },
+      });
+
+      wrapper.vm.$nextTick(() => {
+        expect(wrapper.find('.vti__input').attributes('inputmode')).toBe('tel');
+      })
+    });
     it('.name sets `name` native attribute of input', () => {
       const wrapper = shallowMount(VueTelInput, {
         props: {

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -61,6 +61,7 @@
            :type="inputOptions.type"
            :autocomplete="inputOptions.autocomplete"
            :autofocus="inputOptions.autofocus"
+           :inputmode="inputOptions.inputmode"
            :class="['vti__input', 'vti__phone', inputOptions.styleClasses]"
            :disabled="disabled"
            :id="inputOptions.id"

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -44,6 +44,16 @@ export interface DropdownOptions {
     tabindex?: number;
 }
 
+export type InputMode =
+    | "none"
+    | "text"
+    | "tel"
+    | "url"
+    | "email"
+    | "numeric"
+    | "decimal"
+    | "search";
+
 export interface InputOptions {
     /**
      * Native input autocomplete attribute
@@ -65,6 +75,11 @@ export interface InputOptions {
      * @default ''
      */
     id?: string;
+    /**
+     * Native input inputmode attribute
+     * @default undefined
+     */
+    inputmode?: InputMode;
     /**
      * Native input maxlength attribute
      * @default 25

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,6 +185,13 @@ export const allProps = [
     inDemo: false,
   },
   {
+    name: 'inputOptions.inputmode',
+    default: undefined,
+    type: String,
+    description: 'Native input <code>inputmode</code> attribute',
+    inDemo: false,
+  },
+  {
     name: 'inputOptions.maxlength',
     default: 25,
     type: Number,


### PR DESCRIPTION
This adds inputmode to the component inputOptions so consumers can pass values like 'tel' without TypeScript errors.

The change wires the option through the Vue component, updates the published type definitions, adds it to the default option metadata, and covers it with a small test.

Closes #495 