### PR TITLE
fix: prevent infinite reactive loop crash on IDD format numbers

### DIFF
--- a/src/components/vue-tel-input.test.ts
+++ b/src/components/vue-tel-input.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import { describe, beforeEach, it, expect, vi } from 'vitest'
 
 import VueTelInput from './vue-tel-input.vue';
@@ -462,6 +462,71 @@ describe('Props', () => {
       });
     });
   });
+  describe('IDD format numbers (e.g. 006595554721)', () => {
+    // 006595554721 = 00 (IDD) + 65 (Singapore) + 95554721 (subscriber)
+    it('resolves an IDD number to the right country without an infinite reactive loop', async () => {
+      // Full mount + v-model + autoFormat to exercise the real reactive flow.
+      const errors: unknown[] = [];
+      const wrapper = mount(VueTelInput, {
+        props: {
+          modelValue: '',
+          defaultCountry: 'FR', // France uses 00 as its IDD prefix
+          autoDefaultCountry: false,
+        },
+      });
+      await wrapper.vm.$nextTick();
+      wrapper.vm.$.appContext.config.errorHandler = (err) => { errors.push(err); };
+
+      await wrapper.setProps({ modelValue: '006595554721' });
+      for (let i = 0; i < 20; i += 1) await wrapper.vm.$nextTick();
+
+      // No "Maximum recursive updates exceeded" crash, resolves to SG not PY.
+      expect(errors.filter((e) => String(e).includes('recursive'))).toHaveLength(0);
+      expect(wrapper.vm.phoneObject.valid).toBe(true);
+      expect(wrapper.vm.phoneObject.country).toBe('SG');
+      expect(wrapper.vm.data.phone.startsWith('+65')).toBe(true);
+      expect(wrapper.vm.data.activeCountryCode).toBe('SG');
+    });
+
+    it('does not oscillate when autoFormat is disabled (phone keeps the IDD prefix)', async () => {
+      const errors: unknown[] = [];
+      const wrapper = mount(VueTelInput, {
+        props: {
+          modelValue: '',
+          defaultCountry: 'FR',
+          autoDefaultCountry: false,
+          autoFormat: false,
+        },
+      });
+      await wrapper.vm.$nextTick();
+      wrapper.vm.$.appContext.config.errorHandler = (err) => { errors.push(err); };
+
+      await wrapper.setProps({ modelValue: '006595554721' });
+      for (let i = 0; i < 20; i += 1) await wrapper.vm.$nextTick();
+
+      // Digits kept as-is, still valid, active country stays the calling context.
+      expect(errors.filter((e) => String(e).includes('recursive'))).toHaveLength(0);
+      expect(wrapper.vm.phoneObject.valid).toBe(true);
+      expect(wrapper.vm.phoneObject.country).toBe('SG');
+      expect(wrapper.vm.data.activeCountryCode).toBe('FR');
+    });
+
+    it('keeps the number invalid when the active country does not use 00 as IDD', async () => {
+      const wrapper = shallowMount(VueTelInput, {
+        props: {
+          defaultCountry: 'US', // US uses 011 as its IDD prefix
+          autoDefaultCountry: false,
+        },
+      });
+
+      await wrapper.vm.$nextTick();
+      wrapper.vm.data.phone = '006595554721';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.phoneObject.valid).toBeFalsy();
+    });
+  });
+
   describe(':styleClasses', () => {
     it('sets classes along side with .vue-tel-input', () => {
       const wrapper = shallowMount(VueTelInput, {

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -314,7 +314,13 @@
     }
 
     if (meta.valid) {
-      meta.formatted = result?.format(toUpperCase(parsedMode.value));
+      // An IDD number (e.g. 006595554721) parses as 'national' but resolves to
+      // a foreign country: format it international so the prefix isn't dropped.
+      const isIddInternational = parsedMode.value === 'national'
+        && result?.country
+        && result.country !== data.activeCountryCode;
+      const effectiveMode = isIddInternational ? 'INTERNATIONAL' : toUpperCase(parsedMode.value);
+      meta.formatted = result?.format(effectiveMode);
     }
 
     if (result?.country
@@ -334,8 +340,12 @@
       ...result,
     }
   })
-  watch(() => phoneObject.value.countryCode, (value) => {
-    if (value) {
+  // Only follow the parsed country once the number is in '+' form, otherwise it
+  // oscillates on IDD numbers (FR→SG→PY→SG…, since SG uses 006 as IDD prefix).
+  // The '+' flag is watched too, so the flag still updates after autoFormat
+  // rewrites the number (countryCode alone doesn't change across that rewrite).
+  watch(() => [phoneObject.value.countryCode, data.phone?.startsWith('+')] as const, ([value, isInternational]) => {
+    if (value && isInternational) {
       data.activeCountryCode = value;
     }
   })


### PR DESCRIPTION
Fixing issue https://github.com/iamstevendao/vue-tel-input/issues/366

A phone number in IDD format such as 006595554721 (00 = international prefix, 65 = Singapore, 95554721 = subscriber) crashed the component with "Maximum recursive updates exceeded" (or silently resolved to the wrong country, Paraguay).

Root cause: the `countryCode` watcher updated `activeCountryCode` after every parse, even for IDD numbers. Singapore uses 006 as its own IDD prefix, so parsing 006595554721 with an SG context yields Paraguay (PY), producing an FR -> SG -> PY -> SG -> ... loop that never settles.

Fixes:
- The country watcher only follows the parsed country for '+' (E.164) numbers, where activeCountryCode is not used as parsing context and so cannot feed back. It also watches the '+' flag, so once autoFormat rewrites an IDD number to '+' form the displayed country flag follows to the real country instead of staying stale.
- phoneObject formats a valid 'national'-mode number as international when the parsed country differs from the active country, preserving the international context instead of stripping it.

Adds regression tests (full mount + v-model + autoFormat) that reproduce the crash, cover the autoFormat-disabled path, and check the invalid case.